### PR TITLE
latex correctly rendered even without spaces around delimiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ next-env.d.ts
 storage/
 temp/
 .claude/
+guide.md

--- a/src/services/htmlMarkdownUtils.test.ts
+++ b/src/services/htmlMarkdownUtils.test.ts
@@ -83,4 +83,38 @@ describe('markdownToHtmlNoImages', () => {
     // Markdown table should have scope="col"
     expect(html).toContain('<th scope="col">MD Header</th>');
   });
+
+  it("can recognize latex with $ delims", () => {
+    const rawMarkdown = `
+This is latex: $x_2$
+    endline`;
+
+    const doc = markdownToHtmlNoImages(rawMarkdown);
+    expect(doc).not.toContain("$");
+    expect(doc).toContain("<mi>x</mi>");
+    expect(doc).not.toContain("x_2");
+  });
+
+  it("can recognize latex with $ delims and no surrounding space", () => {
+    const rawMarkdown = `
+This is latex: ($x_2$)
+    endline`;
+
+    const doc = markdownToHtmlNoImages(rawMarkdown);
+    expect(doc).not.toContain("$");
+    expect(doc).toContain("<mi>x</mi>");
+    expect(doc).not.toContain("x_2");
+  });
+
+  it("can recognize latex with $$ delims and no surrounding space", () => {
+    const rawMarkdown = `
+This is latex: ($$x_2$$)
+    endline`;
+
+    const doc = markdownToHtmlNoImages(rawMarkdown);
+    expect(doc).not.toContain("$");
+    expect(doc).toContain("<mi>x</mi>");
+    expect(doc).not.toContain("x_2");
+  });
+
 });

--- a/src/services/htmlMarkdownUtils.ts
+++ b/src/services/htmlMarkdownUtils.ts
@@ -42,6 +42,7 @@ marked.use(
   markedKatex({
     throwOnError: false,
     output: "mathml",
+    nonStandard: true,
   })
 );
 


### PR DESCRIPTION
Enables [marked katex extension "nonStandard" setting](https://github.com/UziTech/marked-katex-extension/blob/main/README.md#non-standard) which exists to allow latex snippets to be recognized without requiring space around the delimiters (the default in an earlier version of canvas management).

The pull request adds appropriate tests and then enables the setting so that the tests pass. For example: `($x$)` will be correctly as ($x$) rendered whereas previously, spaces would have been required: `( $x$ )` in order to be rendered as ( $x$ ).

The change removes the hassle of adding the space and improves the look of the result.
