### PR TITLE
Fix distractors: correctly send distractors to canvas for matching-type quiz questions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ storage/
 temp/
 .claude/
 guide.md
+.codex

--- a/src/features/canvas/services/canvasQuizService.test.ts
+++ b/src/features/canvas/services/canvasQuizService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { canvasQuizService } from "./canvasQuizService";
+import { canvasQuizService, getAnswersForCanvas } from "./canvasQuizService";
 import { CanvasQuizQuestion } from "@/features/canvas/models/quizzes/canvasQuizQuestionModel";
 import { LocalQuiz } from "@/features/local/quizzes/models/localQuiz";
 import { QuestionType } from "@/features/local/quizzes/models/localQuizQuestion";
@@ -16,6 +16,11 @@ vi.mock("@/services/axiosUtils", () => ({
 vi.mock("./canvasServiceUtils", () => ({
   canvasApi: "https://test.instructure.com/api/v1",
   paginatedRequest: vi.fn(),
+}));
+
+vi.mock("./canvasWebRequestUtils", () => ({
+  rateLimitAwarePost: vi.fn(),
+  rateLimitAwareDelete: vi.fn(),
 }));
 
 vi.mock("./canvasAssignmentService", () => ({
@@ -220,6 +225,91 @@ describe("canvasQuizService", () => {
       expect(result[0].position).toBe(1);
       expect(result[1].position).toBe(2);
       expect(result[2].position).toBe(3);
+    });
+  });
+
+  describe("getAnswersForCanvas", () => {
+    it("includes matching distractors", () => {
+      const answers = getAnswersForCanvas(
+        {
+          text: "Match the following terms",
+          questionType: QuestionType.MATCHING,
+          points: 2,
+          answers: [
+            {
+              text: "statement",
+              matchedText: "a single command to be executed",
+              correct: true,
+            },
+          ],
+          matchDistractors: ["reserved word"],
+        },
+        {} as never
+      );
+
+      expect(answers).toEqual([
+        {
+          answer_match_left: "statement",
+          answer_match_right: "a single command to be executed",
+          matching_answer_incorrect_matches: "reserved word",
+        },
+      ]);
+    });
+  });
+
+  describe("create", () => {
+    it("sends matching distractors on the question payload", async () => {
+      const { rateLimitAwarePost } = await import("./canvasWebRequestUtils");
+
+      vi.spyOn(canvasQuizService, "getQuizQuestions").mockResolvedValue([]);
+      vi.mocked(rateLimitAwarePost).mockImplementation(async () => ({
+        data: { id: 1 },
+      }) as never);
+
+      await canvasQuizService.create(
+        42,
+        {
+          name: "Matching Quiz",
+          description: "",
+          dueAt: "2023-12-01T23:59:00Z",
+          shuffleAnswers: false,
+          showCorrectAnswers: true,
+          oneQuestionAtATime: false,
+          allowedAttempts: 1,
+          questions: [
+            {
+              text: "Match the following terms",
+              questionType: QuestionType.MATCHING,
+              points: 2,
+              answers: [
+                {
+                  text: "statement",
+                  matchedText: "a single command to be executed",
+                  correct: true,
+                },
+              ],
+              matchDistractors: ["reserved word"],
+            },
+          ],
+        } as LocalQuiz,
+        {} as never
+      );
+
+      const questionRequest = vi
+        .mocked(rateLimitAwarePost)
+        .mock.calls.find(([url]) => url.endsWith("/questions"));
+
+      const questionPayload = questionRequest?.[1] as
+        | {
+            question?: {
+              matching_answer_incorrect_matches?: string;
+            };
+          }
+        | undefined;
+
+      expect(questionPayload?.question?.matching_answer_incorrect_matches).toBe(
+        "reserved word"
+      );
     });
   });
 });

--- a/src/features/canvas/services/canvasQuizService.ts
+++ b/src/features/canvas/services/canvasQuizService.ts
@@ -20,7 +20,8 @@ export const getAnswersForCanvas = (
   question: LocalQuizQuestion,
   settings: LocalCourseSettings
 ) => {
-  if (question.questionType === QuestionType.MATCHING)
+  if (question.questionType === QuestionType.MATCHING) {
+    const distractors = question.matchDistractors.join("\n");
     return question.answers.map((a) => {
       const text =
         question.questionType === QuestionType.MATCHING
@@ -29,8 +30,12 @@ export const getAnswersForCanvas = (
       return {
         answer_match_left: text,
         answer_match_right: a.matchedText,
+        ...(distractors
+          ? { matching_answer_incorrect_matches: distractors }
+          : {}),
       };
     });
+  }
 
   if (question.questionType === QuestionType.NUMERICAL) {
     // if (question.answers[0].numericalAnswerType === "range_answer") {
@@ -94,6 +99,13 @@ const createQuestionOnly = async (
       question_type: getQuestionTypeForCanvas(question),
       points_possible: question.points,
       position,
+      ...(question.questionType === QuestionType.MATCHING &&
+      question.matchDistractors.length > 0
+        ? {
+            matching_answer_incorrect_matches:
+              question.matchDistractors.join("\n"),
+          }
+        : {}),
       answers: getAnswersForCanvas(question, settings),
       correct_comments: question.incorrectComments,
       incorrect_comments: question.incorrectComments,

--- a/src/services/htmlMarkdownUtils.node.test.ts
+++ b/src/services/htmlMarkdownUtils.node.test.ts
@@ -1,0 +1,13 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { markdownToHtmlNoImages } from "./htmlMarkdownUtils";
+
+describe("markdownToHtmlNoImages in node", () => {
+  it("sanitizes html without crashing", () => {
+    const markdown = `<script>alert("xss")</script><p>safe</p>`;
+
+    expect(() => markdownToHtmlNoImages(markdown)).not.toThrow();
+    expect(markdownToHtmlNoImages(markdown)).not.toContain("<script>");
+  });
+});

--- a/src/services/htmlMarkdownUtils.ts
+++ b/src/services/htmlMarkdownUtils.ts
@@ -1,6 +1,6 @@
 "use client";
 import { marked } from "marked";
-import DOMPurify from "dompurify";
+import DOMPurify from "isomorphic-dompurify";
 import markedKatex from "marked-katex-extension";
 import pako from "pako";
 import { LocalCourseSettings } from "@/features/local/course/localCourseSettings";


### PR DESCRIPTION
Before, distractors in "matching" questions for quizzes were correctly parsed and displayed locally, but they weren't being included in the actual canvas quiz objects.
This also adds the more thorough tests that captured the missing functionality (isomorphic-dompurify works in Node.js without requiring a real browser DOM).
